### PR TITLE
Patch bonobo bug with hardware breakpoints

### DIFF
--- a/src/target/breakpoints.c
+++ b/src/target/breakpoints.c
@@ -232,9 +232,12 @@ int breakpoint_add(struct target *target,
 
 		while (head != (struct target_list *)NULL) {
 			curr = head->target;
-			retval = breakpoint_add_internal(curr, address, length, type);
-			if (retval != ERROR_OK)
-				return retval;
+ 			if(curr->state != TARGET_POWEROFF) {
+				retval = breakpoint_add_internal(curr, address, length, type);
+				if (retval != ERROR_OK)
+					return retval;
+			}
+
 			head = head->next;
 		}
 		return retval;


### PR DESCRIPTION
For the t8010 target, attempting to insert a hardware breakpoint on iphone.cpu0 also adds a breakpoint at the same address for iphone.cpu1 which could be powered off. This causes an error, which makes gdb unable to proceed even if the desired breakpoint was set successfully. 

I'm sure there's scenarios where setting a breakpoint on both CPUs is desired, so this isn't a fix and more of a patch to get things to work correctly for my use. However, it might be worth it to address how the iphone.cpu1 target is added to the target list even when iphone.cpu0 is the selected core.